### PR TITLE
Add three classical forecasting baselines for energy time series

### DIFF
--- a/README.md
+++ b/README.md
@@ -1204,6 +1204,21 @@ If you find this project helpful, please don't forget to give it a ⭐ Star to s
   ICML, 2013.  
   [Paper](http://proceedings.mlr.press/v28/ganeshapillai13.pdf)
 
+- **Benchmarks for solar radiation time series forecasting**  
+  Cyril Voyant; Gilles Notton; Jean-Laurent Duchaud; Luis Antonio Garcia-Gutierrez; Jamie M. Bright; Dazhi Yang  
+  Renewable Energy, 2022.  
+  [Paper](https://doi.org/10.1016/j.renene.2022.04.065) | [Codes](https://github.com/cyrilvoyant/ARTU)
+
+- **Cyclostationary persistence operators (BLEND, CLIPER) for periodic energy time series**  
+  Cyril Voyant; Candice Banes; Luis Garcia-Gutierrez; Gilles Notton; Milan Despotovic; Zaher Mundher Yaseen  
+  arXiv, 2026.  
+  [Paper](https://arxiv.org/abs/2602.18949) | [Codes](https://github.com/cyrilvoyant/cyclostationary-forecasting-matlab)
+
+- **Does stationarization help? A frugal benchmark of deseasonalization for renewable energy forecasting**  
+  Maklewa Agoundedemba; Cyril Voyant; Milan Despotovic; Luis Antonio Garcia-Gutierrez; Gilles Notton  
+  2026.  
+  [Codes](https://github.com/cyrilvoyant/Make_Stationary)
+
 ## H. Quantitative Open Sourced Framework
 
 - **RD-Agent: Autonomous evolving agents for industrial data-drive R&D**  


### PR DESCRIPTION
Three entries added to *G. Classical Time Series Models*, each with released code.

- **Benchmarks for solar radiation time series forecasting** (*Renewable Energy* 191, 2022) - defines ARTU, a second-order autoregressive reference, alongside persistence, climatology, CLIPER and exponential smoothing. Useful as a non-deep baseline set when reporting skill scores.
- **Cyclostationary persistence operators (BLEND, CLIPER)** (arXiv, 2026) - closed-form, training-free operators that optimally blend simple and cyclic persistence under periodic non-stationarity.
- **Does stationarization help?** (2026) - a frugal benchmark of deseasonalization strategies, using a ridge-regularized ELM to extract a phase-based seasonal component.

The section currently holds a single entry; these add non-deep baselines that are widely used as reference points in energy forecasting. All code is MIT-licensed MATLAB.

Disclosure: I am a co-author of these works.